### PR TITLE
Update Terraform Manifests for K8s 1.22+ API

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "kubernetes_deployment" "aphorismophilia" {
           image_pull_policy = "Always"
 
           resources {
-            requests {
+            requests = {
               cpu    = "100m"
               memory = "30Mi"
             }

--- a/main.tf
+++ b/main.tf
@@ -105,7 +105,7 @@ resource "kubernetes_service" "aphorismophilia-service" {
   }
 }
 
-resource "kubernetes_ingress" "aphorismophilia-ingress" {
+resource "kubernetes_ingress_v1" "aphorismophilia-ingress" {
   metadata {
     name      = "aphorismophilia-ingress"
     namespace = var.service_aphorismophilia_namespace
@@ -119,8 +119,12 @@ resource "kubernetes_ingress" "aphorismophilia-ingress" {
       http {
         path {
           backend {
-            service_name = "aphorismophilia-service"
-            service_port = "8888"
+            service {
+              name = "aphorismophilia-service"
+              port {
+                number = 8888
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This PR is a prerequisite to https://github.com/mikeroach/iac-template-pipeline/pull/1 which updates the aphorismophilia service's Terraform manifests to:

* Use the Kubernetes 1.22+ stable Ingress API
* Change resources syntax for compatibility with the latest Kubernetes Terraform provider