### PR TITLE
Rename Default Branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
         }
         stage('Tag Module Release') {
             when {
-                branch 'master'
+                branch 'main'
             }
             steps {
                 withCredentials([usernamePassword(credentialsId: 'GitHub_Jenkins-GCP', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
@@ -42,7 +42,7 @@ pipeline {
                      description: 'All tests passed',
                      targetUrl: "${env.BUILD_URL}/display/redirect")
 
-                    // Attempt to auto-merge this PR into master unless the 'no-merge' label exists to indicate otherwise.
+                    // Attempt to auto-merge this PR into main unless the 'no-merge' label exists to indicate otherwise.
                     if (! pullRequest.labels.contains("no-merge")) {
                         echo "No-merge label absent; attempting auto-merge."
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Currently this pseudo-Terraservice's pipeline simply performs rudimentary Terraf
 
 1. IaC engineer develops and tests locally in feature branch.
 1. IaC engineer commits feature branch and submits pull request.
-1. Jenkins examines pull request, runs validation tests, and merges into master upon success.
-1. Jenkins repeats validation tests against master branch and tags new release upon success.
+1. Jenkins examines pull request, runs validation tests, and merges into `main` upon success.
+1. Jenkins repeats validation tests against `main` branch and tags new release upon success.
 1. Stack and template owners update their ephemeral environment definitions and templates with new version tag.


### PR DESCRIPTION
This PR updates the repository's default branch to `main` in code and documentation to embrace recommended inclusive terminology per [IETF Internet-Draft draft-knodel-terminology-12](https://datatracker.ietf.org/doc/draft-knodel-terminology/).